### PR TITLE
Add LoginForm module

### DIFF
--- a/public/src/components/modules/LoginForm/LoginForm.css
+++ b/public/src/components/modules/LoginForm/LoginForm.css
@@ -1,0 +1,22 @@
+/* public/src/components/modules/LoginForm/LoginForm.css */
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+.login-form__heading {
+  text-align: center;
+}
+
+.login-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.login-form__submit {
+  align-self: center;
+}

--- a/public/src/components/modules/LoginForm/LoginForm.js
+++ b/public/src/components/modules/LoginForm/LoginForm.js
@@ -1,0 +1,46 @@
+import { loadCSS } from '../../../utils/cssLoader.js';
+loadCSS('./src/components/modules/LoginForm/LoginForm.css');
+
+import { Heading } from '../../primitives/Heading/Heading.js';
+import { Label } from '../../primitives/Label/Label.js';
+import { Input } from '../../primitives/Input/input.js';
+import { Button } from '../../primitives/Button/Button.js';
+
+export function LoginForm({ onSubmit = () => {} } = {}) {
+  const form = document.createElement('form');
+  form.classList.add('login-form');
+
+  const heading = Heading({ level: 2, text: 'Login', className: 'login-form__heading' });
+
+  const emailField = document.createElement('div');
+  emailField.classList.add('login-form__field');
+  const emailId = 'login-email';
+  const emailLabel = Label({ htmlFor: emailId, text: 'Email' });
+  const emailInput = Input({ type: 'email', placeholder: 'you@example.com' });
+  emailInput.id = emailId;
+  emailField.append(emailLabel, emailInput);
+
+  const passwordField = document.createElement('div');
+  passwordField.classList.add('login-form__field');
+  const passwordId = 'login-password';
+  const passwordLabel = Label({ htmlFor: passwordId, text: 'Password' });
+  const passwordInput = Input({ type: 'password', placeholder: '********' });
+  passwordInput.id = passwordId;
+  passwordField.append(passwordLabel, passwordInput);
+
+  const submitButton = Button({ text: 'Login', type: 'submit', onClick: () => {} });
+  submitButton.classList.add('login-form__submit');
+
+  form.append(heading, emailField, passwordField, submitButton);
+
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    onSubmit({
+      email: emailInput.value,
+      password: passwordInput.value
+    });
+  });
+
+  return form;
+}
+


### PR DESCRIPTION
## Summary
- implement LoginForm module combining primitive components for email/password authentication and submission
- add styles for LoginForm layout and spacing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688ff8cf6d248328b4deb948093bca3f