### PR TITLE
feat: add FeatureCard module

### DIFF
--- a/public/src/components/modules/FeatureCard/FeatureCard.css
+++ b/public/src/components/modules/FeatureCard/FeatureCard.css
@@ -1,0 +1,35 @@
+.feature-card {
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 1rem;
+  max-width: 100%;
+  margin: 1rem auto;
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+}
+
+.feature-card__title {
+  margin-bottom: 0.5rem;
+}
+
+.feature-card__description {
+  margin-bottom: 1rem;
+  color: #555;
+}
+
+.feature-card__button {
+  align-self: center;
+}
+
+@media (min-width: 600px) {
+  .feature-card {
+    max-width: 400px;
+    padding: 2rem;
+    text-align: left;
+  }
+
+  .feature-card__button {
+    align-self: flex-start;
+  }
+}

--- a/public/src/components/modules/FeatureCard/FeatureCard.js
+++ b/public/src/components/modules/FeatureCard/FeatureCard.js
@@ -1,0 +1,28 @@
+import { loadCSS } from '../../../utils/cssLoader.js';
+loadCSS('./src/components/modules/FeatureCard/FeatureCard.css');
+
+import { Heading } from '../../primitives/Heading/Heading.js';
+import { Text } from '../../primitives/Text/Text.js';
+import { Button } from '../../primitives/Button/Button.js';
+
+export function FeatureCard({
+  title = 'Feature title',
+  description = 'Short description of the feature.',
+  ctaText = 'Learn more',
+  onCtaClick = () => {}
+} = {}) {
+  const container = document.createElement('article');
+  container.classList.add('feature-card');
+  container.setAttribute('role', 'region');
+
+  const headingId = `feature-card-title-${Math.random().toString(36).slice(2, 9)}`;
+  const headingEl = Heading({ level: 3, text: title, className: 'feature-card__title' });
+  headingEl.id = headingId;
+  container.setAttribute('aria-labelledby', headingId);
+  const descriptionEl = Text({ tag: 'p', text: description, className: 'feature-card__description' });
+  const buttonEl = Button({ text: ctaText, onClick: onCtaClick });
+  buttonEl.classList.add('feature-card__button');
+
+  container.append(headingEl, descriptionEl, buttonEl);
+  return container;
+}


### PR DESCRIPTION
## Summary
- add FeatureCard module built from Heading, Text, and Button primitives
- style FeatureCard with responsive CSS and ARIA labelling for accessibility

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688ffe723cc483289a84d4b101819331