### PR TITLE
feat: add testimonial card module

### DIFF
--- a/public/src/components/modules/TestimonialCard/TestimonialCard.css
+++ b/public/src/components/modules/TestimonialCard/TestimonialCard.css
@@ -1,0 +1,35 @@
+/* public/src/components/modules/TestimonialCard/TestimonialCard.css */
+.testimonial-card {
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 1rem;
+  max-width: 100%;
+  margin: 1rem auto;
+  background-color: #fff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.testimonial-card__quote {
+  font-style: italic;
+  margin: 0 0 1rem;
+}
+
+.testimonial-card__author-name {
+  margin: 0;
+}
+
+.testimonial-card__author-role {
+  margin: 0;
+  color: #555;
+  font-size: 0.875rem;
+}
+
+@media (min-width: 600px) {
+  .testimonial-card {
+    padding: 2rem;
+    max-width: 600px;
+  }
+}

--- a/public/src/components/modules/TestimonialCard/TestimonialCard.js
+++ b/public/src/components/modules/TestimonialCard/TestimonialCard.js
@@ -1,0 +1,27 @@
+import { loadCSS } from '../../../utils/cssLoader.js';
+loadCSS('./src/components/modules/TestimonialCard/TestimonialCard.css');
+
+import { Heading } from '../../primitives/Heading/Heading.js';
+import { Text } from '../../primitives/Text/Text.js';
+
+export function TestimonialCard({
+  quote = 'This product changed my life!',
+  author = 'Jane Doe',
+  role = 'CEO, Example Inc.'
+} = {}) {
+  const container = document.createElement('figure');
+  container.classList.add('testimonial-card');
+
+  const quoteEl = Text({ tag: 'blockquote', text: quote, className: 'testimonial-card__quote' });
+
+  const figcaption = document.createElement('figcaption');
+  figcaption.classList.add('testimonial-card__author');
+
+  const authorEl = Heading({ level: 3, text: author, className: 'testimonial-card__author-name' });
+  const roleEl = Text({ tag: 'p', text: role, className: 'testimonial-card__author-role' });
+
+  figcaption.append(authorEl, roleEl);
+  container.append(quoteEl, figcaption);
+
+  return container;
+}


### PR DESCRIPTION
## Summary
- add TestimonialCard module composed from Heading and Text primitives
- style card with responsive layout and accessible structure

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688fffca4010832883928e6030150fd6