### PR TITLE
feat: add alert banner module

### DIFF
--- a/public/src/components/modules/AlertBanner/AlertBanner.css
+++ b/public/src/components/modules/AlertBanner/AlertBanner.css
@@ -1,0 +1,58 @@
+/* public/src/components/modules/AlertBanner/AlertBanner.css */
+.alert-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem;
+  border-radius: 4px;
+  margin: 1rem 0;
+}
+
+.alert-banner__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.alert-banner__heading {
+  margin: 0;
+}
+
+.alert-banner__message {
+  margin: 0;
+}
+
+.alert-banner__close {
+  background: transparent;
+  border: none;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+@media (max-width: 600px) {
+  .alert-banner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .alert-banner__close {
+    align-self: flex-end;
+    margin-top: 0.5rem;
+  }
+}
+
+.alert-banner--info {
+  background-color: #e5f6ff;
+  color: #0c5460;
+}
+
+.alert-banner--success {
+  background-color: #d4edda;
+  color: #155724;
+}
+
+.alert-banner--error {
+  background-color: #f8d7da;
+  color: #721c24;
+}

--- a/public/src/components/modules/AlertBanner/AlertBanner.js
+++ b/public/src/components/modules/AlertBanner/AlertBanner.js
@@ -1,0 +1,39 @@
+import { loadCSS } from '../../../utils/cssLoader.js';
+loadCSS('./src/components/modules/AlertBanner/AlertBanner.css');
+
+import { Heading } from '../../primitives/Heading/Heading.js';
+import { Text } from '../../primitives/Text/Text.js';
+import { Button } from '../../primitives/Button/Button.js';
+
+export function AlertBanner({
+  heading = 'Notice',
+  message = 'This is an alert message.',
+  type = 'info',
+  onClose = () => {}
+} = {}) {
+  const container = document.createElement('div');
+  container.classList.add('alert-banner', `alert-banner--${type}`);
+  container.setAttribute('role', 'alert');
+  container.setAttribute('aria-live', 'assertive');
+
+  const content = document.createElement('div');
+  content.classList.add('alert-banner__content');
+
+  const headingEl = Heading({ level: 4, text: heading, className: 'alert-banner__heading' });
+  const messageEl = Text({ tag: 'p', text: message, className: 'alert-banner__message' });
+
+  content.append(headingEl, messageEl);
+
+  const closeButton = Button({ text: '×', onClick: handleClose });
+  closeButton.classList.add('alert-banner__close');
+  closeButton.setAttribute('aria-label', 'Close alert');
+
+  function handleClose() {
+    container.remove();
+    onClose();
+  }
+
+  container.append(content, closeButton);
+
+  return container;
+}


### PR DESCRIPTION
## Summary
- add AlertBanner module using Heading, Text and Button primitives
- style alert for info/success/error variants with responsive layout and dismiss button

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6890009c06e0832899f81f6415c8dd2f