### PR TITLE
feat: add responsive navigation bar module

### DIFF
--- a/public/src/components/modules/NavigationBar/NavigationBar.css
+++ b/public/src/components/modules/NavigationBar/NavigationBar.css
@@ -1,0 +1,48 @@
+/* public/src/components/modules/NavigationBar/NavigationBar.css */
+.navigation-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  background-color: #fff;
+  border-bottom: 1px solid #ddd;
+}
+
+.navigation-bar__brand {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.navigation-bar__toggle {
+  display: none;
+  background: transparent;
+  border: 1px solid #333;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+}
+
+.navigation-bar__menu {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+@media (max-width: 600px) {
+  .navigation-bar__toggle {
+    display: block;
+  }
+  .navigation-bar__menu {
+    display: none;
+    flex-direction: column;
+    width: 100%;
+  }
+  .navigation-bar__menu.navigation-bar__menu--open {
+    display: flex;
+  }
+  .navigation-bar__menu li {
+    padding: 0.5rem 0;
+  }
+}
+

--- a/public/src/components/modules/NavigationBar/NavigationBar.js
+++ b/public/src/components/modules/NavigationBar/NavigationBar.js
@@ -1,0 +1,46 @@
+import { loadCSS } from '../../../utils/cssLoader.js';
+loadCSS('./src/components/modules/NavigationBar/NavigationBar.css');
+
+import { Heading } from '../../primitives/Heading/Heading.js';
+import { Link } from '../../primitives/Link/Link.js';
+import { Button } from '../../primitives/Button/Button.js';
+
+export function NavigationBar({
+  brand = 'Brand',
+  links = []
+} = {}) {
+  const nav = document.createElement('nav');
+  nav.classList.add('navigation-bar');
+  nav.setAttribute('role', 'navigation');
+  nav.setAttribute('aria-label', 'Main navigation');
+
+  const brandEl = Heading({ level: 1, text: brand, className: 'navigation-bar__brand' });
+
+  const menu = document.createElement('ul');
+  menu.classList.add('navigation-bar__menu');
+  menu.id = 'navigation-bar-menu';
+
+  links.forEach(({ href, text }) => {
+    const li = document.createElement('li');
+    const link = Link({ href, text });
+    li.append(link);
+    menu.append(li);
+  });
+
+  const toggleButton = Button({ text: 'Menu', onClick: toggleMenu });
+  toggleButton.classList.add('navigation-bar__toggle');
+  toggleButton.setAttribute('aria-label', 'Toggle navigation');
+  toggleButton.setAttribute('aria-controls', 'navigation-bar-menu');
+  toggleButton.setAttribute('aria-expanded', 'false');
+
+  function toggleMenu() {
+    const expanded = toggleButton.getAttribute('aria-expanded') === 'true';
+    toggleButton.setAttribute('aria-expanded', String(!expanded));
+    menu.classList.toggle('navigation-bar__menu--open');
+  }
+
+  nav.append(brandEl, toggleButton, menu);
+
+  return nav;
+}
+


### PR DESCRIPTION
## Summary
- add NavigationBar module built from primitives (Heading, Link, Button)
- style navigation with responsive mobile menu toggle

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6890024561c88328a7d27fddbb51c4e1