### PR TITLE
feat: add ProfileCard module

### DIFF
--- a/public/src/components/modules/ProfileCard/ProfileCard.css
+++ b/public/src/components/modules/ProfileCard/ProfileCard.css
@@ -1,0 +1,55 @@
+.profile-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 1rem;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  max-width: 100%;
+  margin: 1rem auto;
+  text-align: center;
+}
+
+.profile-card__image {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  object-fit: cover;
+  margin-bottom: 1rem;
+}
+
+.profile-card__name {
+  margin-bottom: 0.25rem;
+}
+
+.profile-card__title {
+  margin-bottom: 1rem;
+  color: #555;
+}
+
+.profile-card__button {
+  align-self: center;
+}
+
+@media (min-width: 600px) {
+  .profile-card {
+    flex-direction: row;
+    text-align: left;
+    max-width: 600px;
+  }
+
+  .profile-card__image {
+    margin-right: 1.5rem;
+    margin-bottom: 0;
+  }
+
+  .profile-card__button {
+    align-self: flex-start;
+  }
+
+  .profile-card__content {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+}

--- a/public/src/components/modules/ProfileCard/ProfileCard.js
+++ b/public/src/components/modules/ProfileCard/ProfileCard.js
@@ -1,0 +1,43 @@
+import { loadCSS } from '../../../utils/cssLoader.js';
+loadCSS('./src/components/modules/ProfileCard/ProfileCard.css');
+
+import { Heading } from '../../primitives/Heading/Heading.js';
+import { Text } from '../../primitives/Text/Text.js';
+import { Button } from '../../primitives/Button/Button.js';
+
+export function ProfileCard({
+  name = 'John Doe',
+  title = 'Job Title',
+  imageUrl = '',
+  imageAlt = '',
+  contactText = 'Contact',
+  onContact = () => {}
+} = {}) {
+  const card = document.createElement('article');
+  card.classList.add('profile-card');
+  card.setAttribute('role', 'region');
+
+  const headingId = `profile-card-name-${Math.random().toString(36).slice(2, 9)}`;
+
+  const imgEl = document.createElement('img');
+  imgEl.src = imageUrl;
+  imgEl.alt = imageAlt || `Portrait of ${name}`;
+  imgEl.classList.add('profile-card__image');
+
+  const contentEl = document.createElement('div');
+  contentEl.classList.add('profile-card__content');
+
+  const nameEl = Heading({ level: 3, text: name, className: 'profile-card__name' });
+  nameEl.id = headingId;
+  card.setAttribute('aria-labelledby', headingId);
+
+  const titleEl = Text({ tag: 'p', text: title, className: 'profile-card__title' });
+
+  const buttonEl = Button({ text: contactText, onClick: onContact });
+  buttonEl.classList.add('profile-card__button');
+
+  contentEl.append(nameEl, titleEl, buttonEl);
+  card.append(imgEl, contentEl);
+
+  return card;
+}


### PR DESCRIPTION
## Summary
- add ProfileCard module built from primitives
- style profile card with responsive flexbox layout

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68900427215c8328836a54954ffe5168