### PR TITLE
feat: add StatsGrid module

### DIFF
--- a/public/src/components/modules/StatsGrid/StatsGrid.css
+++ b/public/src/components/modules/StatsGrid/StatsGrid.css
@@ -1,0 +1,39 @@
+.stats-grid {
+  padding: 1rem;
+  max-width: 100%;
+  margin: 0 auto;
+}
+
+.stats-grid__title {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.stats-grid__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1rem;
+}
+
+.stats-grid__item {
+  text-align: center;
+}
+
+.stats-grid__value {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.stats-grid__label {
+  margin: 0.25rem 0 0;
+  color: #555;
+}
+
+@media (min-width: 600px) {
+  .stats-grid__value {
+    font-size: 2rem;
+  }
+}

--- a/public/src/components/modules/StatsGrid/StatsGrid.js
+++ b/public/src/components/modules/StatsGrid/StatsGrid.js
@@ -1,0 +1,36 @@
+import { loadCSS } from '../../../utils/cssLoader.js';
+loadCSS('./src/components/modules/StatsGrid/StatsGrid.css');
+
+import { Heading } from '../../primitives/Heading/Heading.js';
+import { Text } from '../../primitives/Text/Text.js';
+
+export function StatsGrid({
+  title = 'Key Statistics',
+  stats = []
+} = {}) {
+  const section = document.createElement('section');
+  section.classList.add('stats-grid');
+  section.setAttribute('role', 'region');
+
+  const headingId = `stats-grid-title-${Math.random().toString(36).slice(2, 9)}`;
+  const headingEl = Heading({ level: 2, text: title, className: 'stats-grid__title' });
+  headingEl.id = headingId;
+  section.setAttribute('aria-labelledby', headingId);
+
+  const listEl = document.createElement('ul');
+  listEl.classList.add('stats-grid__list');
+
+  stats.forEach(({ value, label }) => {
+    const itemEl = document.createElement('li');
+    itemEl.classList.add('stats-grid__item');
+
+    const valueEl = Heading({ level: 3, text: value, className: 'stats-grid__value' });
+    const labelEl = Text({ tag: 'p', text: label, className: 'stats-grid__label' });
+
+    itemEl.append(valueEl, labelEl);
+    listEl.append(itemEl);
+  });
+
+  section.append(headingEl, listEl);
+  return section;
+}


### PR DESCRIPTION
## Summary
- add StatsGrid module using Heading and Text primitives
- style module with responsive grid layout

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6890063f74908328a0ae777c1e4f29e1