### PR TITLE
feat: add call to action banner module

### DIFF
--- a/public/src/components/modules/CallToActionBanner/CallToActionBanner.css
+++ b/public/src/components/modules/CallToActionBanner/CallToActionBanner.css
@@ -1,0 +1,40 @@
+.cta-banner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 2rem 1rem;
+  background-color: #f5f5f5;
+}
+
+.cta-banner__heading {
+  margin-bottom: 0.5rem;
+}
+
+.cta-banner__message {
+  margin-bottom: 1rem;
+  max-width: 40rem;
+}
+
+.cta-banner__button {
+  align-self: center;
+}
+
+@media (min-width: 600px) {
+  .cta-banner {
+    flex-direction: row;
+    justify-content: space-between;
+    text-align: left;
+    padding: 2rem 3rem;
+  }
+
+  .cta-banner__message {
+    margin-bottom: 0;
+    margin-right: 1rem;
+  }
+
+  .cta-banner__button {
+    align-self: center;
+    flex-shrink: 0;
+  }
+}

--- a/public/src/components/modules/CallToActionBanner/CallToActionBanner.js
+++ b/public/src/components/modules/CallToActionBanner/CallToActionBanner.js
@@ -1,0 +1,32 @@
+import { loadCSS } from '../../../utils/cssLoader.js';
+loadCSS('./src/components/modules/CallToActionBanner/CallToActionBanner.css');
+
+import { Heading } from '../../primitives/Heading/Heading.js';
+import { Text } from '../../primitives/Text/Text.js';
+import { Button } from '../../primitives/Button/Button.js';
+
+export function CallToActionBanner({
+  heading = 'Ready to get started?',
+  message = 'Join us and make your workflow more efficient.',
+  buttonText = 'Get Started',
+  onButtonClick = () => {}
+} = {}) {
+  const section = document.createElement('section');
+  section.classList.add('cta-banner');
+  section.setAttribute('role', 'region');
+
+  const headingId = `cta-banner-heading-${Math.random().toString(36).slice(2, 9)}`;
+
+  const headingEl = Heading({ level: 2, text: heading, className: 'cta-banner__heading' });
+  headingEl.id = headingId;
+  section.setAttribute('aria-labelledby', headingId);
+
+  const messageEl = Text({ tag: 'p', text: message, className: 'cta-banner__message' });
+
+  const buttonEl = Button({ text: buttonText, onClick: onButtonClick });
+  buttonEl.classList.add('cta-banner__button');
+
+  section.append(headingEl, messageEl, buttonEl);
+
+  return section;
+}


### PR DESCRIPTION
## Summary
- create `CallToActionBanner` module built from existing primitives
- provide responsive layout for call-to-action content

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68900af6510083288615df1d73a1f2a4