### PR TITLE
feat: add accessible breadcrumbs module

### DIFF
--- a/public/src/components/modules/Breadcrumbs/Breadcrumbs.css
+++ b/public/src/components/modules/Breadcrumbs/Breadcrumbs.css
@@ -1,0 +1,37 @@
+.breadcrumbs {
+  width: 100%;
+  padding: 0.5rem 1rem;
+}
+
+.breadcrumbs__list {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  margin: 0;
+  padding: 0;
+}
+
+.breadcrumbs__item {
+  display: flex;
+  align-items: center;
+}
+
+.breadcrumbs__item:not(:last-child)::after {
+  content: '/';
+  margin: 0 0.5rem;
+  color: #6c757d;
+}
+
+.breadcrumbs__link {
+  text-decoration: none;
+}
+
+.breadcrumbs__current {
+  color: #6c757d;
+}
+
+@media (max-width: 600px) {
+  .breadcrumbs {
+    font-size: 0.875rem;
+  }
+}

--- a/public/src/components/modules/Breadcrumbs/Breadcrumbs.js
+++ b/public/src/components/modules/Breadcrumbs/Breadcrumbs.js
@@ -1,0 +1,34 @@
+import { loadCSS } from '../../../utils/cssLoader.js';
+loadCSS('./src/components/modules/Breadcrumbs/Breadcrumbs.css');
+
+import { Link } from '../../primitives/Link/Link.js';
+import { Text } from '../../primitives/Text/Text.js';
+
+export function Breadcrumbs({ items = [] } = {}) {
+  const nav = document.createElement('nav');
+  nav.classList.add('breadcrumbs');
+  nav.setAttribute('aria-label', 'Breadcrumb');
+
+  const list = document.createElement('ol');
+  list.classList.add('breadcrumbs__list');
+
+  items.forEach(({ href, label }, index) => {
+    const item = document.createElement('li');
+    item.classList.add('breadcrumbs__item');
+
+    if (index < items.length - 1) {
+      const link = Link({ href, text: label });
+      link.classList.add('breadcrumbs__link');
+      item.append(link);
+    } else {
+      const current = Text({ tag: 'span', text: label, className: 'breadcrumbs__current' });
+      item.append(current);
+      item.setAttribute('aria-current', 'page');
+    }
+
+    list.append(item);
+  });
+
+  nav.append(list);
+  return nav;
+}


### PR DESCRIPTION
## Summary
- add Breadcrumbs module using Link and Text primitives
- style Breadcrumbs for responsive layout and current page indication

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68900af6510083288615df1d73a1f2a4