### PR TITLE
Add accessible modal module

### DIFF
--- a/public/src/components/modules/Modal/Modal.css
+++ b/public/src/components/modules/Modal/Modal.css
@@ -1,0 +1,64 @@
+/* public/src/components/modules/Modal/Modal.css */
+.modal {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  z-index: 1000;
+}
+
+.modal__dialog {
+  background-color: #fff;
+  border-radius: 8px;
+  width: 100%;
+  max-width: 500px;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  outline: none;
+}
+
+.modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  border-bottom: 1px solid #eee;
+}
+
+.modal__title {
+  margin: 0;
+}
+
+.modal__close {
+  background: transparent;
+  border: none;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.modal__body {
+  padding: 1rem;
+}
+
+.modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  padding: 1rem;
+  border-top: 1px solid #eee;
+}
+
+.modal__action {
+  /* actions inherit button styles */
+}
+
+@media (max-width: 480px) {
+  .modal__dialog {
+    max-width: 100%;
+  }
+}

--- a/public/src/components/modules/Modal/Modal.js
+++ b/public/src/components/modules/Modal/Modal.js
@@ -1,0 +1,67 @@
+import { loadCSS } from '../../../utils/cssLoader.js';
+loadCSS('./src/components/modules/Modal/Modal.css');
+
+import { Heading } from '../../primitives/Heading/Heading.js';
+import { Text } from '../../primitives/Text/Text.js';
+import { Button } from '../../primitives/Button/Button.js';
+
+export function Modal({
+  title = 'Modal Title',
+  body = 'Modal body text',
+  actions = [],
+  onClose = () => {},
+} = {}) {
+  const overlay = document.createElement('div');
+  overlay.classList.add('modal');
+
+  const dialog = document.createElement('div');
+  dialog.classList.add('modal__dialog');
+  dialog.setAttribute('role', 'dialog');
+  dialog.setAttribute('aria-modal', 'true');
+  const titleId = `modal-title-${Math.random().toString(36).slice(2, 9)}`;
+  const bodyId = `modal-body-${Math.random().toString(36).slice(2, 9)}`;
+  dialog.setAttribute('aria-labelledby', titleId);
+  dialog.setAttribute('aria-describedby', bodyId);
+  dialog.tabIndex = -1;
+
+  const header = document.createElement('div');
+  header.classList.add('modal__header');
+
+  const titleEl = Heading({ level: 2, text: title, className: 'modal__title' });
+  titleEl.id = titleId;
+  header.appendChild(titleEl);
+
+  const closeBtn = Button({ text: '\u00D7', onClick: handleClose });
+  closeBtn.classList.add('modal__close');
+  closeBtn.setAttribute('aria-label', 'Close dialog');
+  header.appendChild(closeBtn);
+
+  const bodyEl = Text({ tag: 'p', text: body, className: 'modal__body' });
+  bodyEl.id = bodyId;
+
+  const footer = document.createElement('div');
+  footer.classList.add('modal__footer');
+
+  actions.forEach(({ text, onClick }) => {
+    const actionBtn = Button({ text, onClick });
+    actionBtn.classList.add('modal__action');
+    footer.appendChild(actionBtn);
+  });
+
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) {
+      handleClose();
+    }
+  });
+
+  function handleClose() {
+    overlay.remove();
+    onClose();
+  }
+
+  setTimeout(() => dialog.focus(), 0);
+
+  dialog.append(header, bodyEl, footer);
+  overlay.appendChild(dialog);
+  return overlay;
+}


### PR DESCRIPTION
## Summary
- create accessible Modal component using Heading, Text, and Button primitives
- include responsive dialog styling and overlay interaction

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689011630f4083288d4900828c73a08a