### PR TITLE
Add accessible SearchBar module

### DIFF
--- a/public/src/components/modules/SearchBar/SearchBar.css
+++ b/public/src/components/modules/SearchBar/SearchBar.css
@@ -1,0 +1,31 @@
+/* public/src/components/modules/SearchBar/SearchBar.css */
+.search-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  max-width: 400px;
+  width: 100%;
+}
+
+.search-bar__label {
+  margin-right: 0.5rem;
+}
+
+.search-bar__input {
+  flex: 1;
+}
+
+@media (max-width: 600px) {
+  .search-bar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .search-bar__label {
+    margin-right: 0;
+  }
+
+  .search-bar__button {
+    width: 100%;
+  }
+}

--- a/public/src/components/modules/SearchBar/SearchBar.js
+++ b/public/src/components/modules/SearchBar/SearchBar.js
@@ -1,0 +1,36 @@
+import { loadCSS } from '../../../utils/cssLoader.js';
+loadCSS('./src/components/modules/SearchBar/SearchBar.css');
+
+import { Input } from '../../primitives/Input/input.js';
+import { Button } from '../../primitives/Button/Button.js';
+import { Label } from '../../primitives/Label/Label.js';
+
+export function SearchBar({
+  placeholder = 'Search...',
+  buttonText = 'Search',
+  labelText = 'Search',
+  onSearch = () => {}
+} = {}) {
+  const form = document.createElement('form');
+  form.classList.add('search-bar');
+  form.setAttribute('role', 'search');
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    const query = inputEl.value.trim();
+    onSearch(query);
+  });
+
+  const labelEl = Label({ htmlFor: 'search-bar-input', text: labelText });
+  labelEl.classList.add('search-bar__label');
+
+  const inputEl = Input({ type: 'search', placeholder });
+  inputEl.id = 'search-bar-input';
+  inputEl.classList.add('search-bar__input');
+
+  const buttonEl = Button({ text: buttonText, type: 'submit', onClick: () => {} });
+  buttonEl.classList.add('search-bar__button');
+
+  form.append(labelEl, inputEl, buttonEl);
+
+  return form;
+}


### PR DESCRIPTION
## Summary
- create SearchBar module built from primitives
- style SearchBar with responsive layout

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689011630f4083288d4900828c73a08a