### PR TITLE
feat: add pagination module

### DIFF
--- a/public/src/components/modules/Pagination/Pagination.css
+++ b/public/src/components/modules/Pagination/Pagination.css
@@ -1,0 +1,36 @@
+/* public/src/components/modules/Pagination/Pagination.css */
+.pagination {
+  display: flex;
+  justify-content: center;
+}
+
+.pagination__list {
+  display: flex;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.pagination__button {
+  min-width: 2.5rem;
+}
+
+.pagination__prev,
+.pagination__next {
+  min-width: 4rem;
+}
+
+@media (max-width: 480px) {
+  .pagination__button {
+    min-width: 2rem;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.875rem;
+  }
+
+  .pagination__prev,
+  .pagination__next {
+    min-width: 3rem;
+  }
+}

--- a/public/src/components/modules/Pagination/Pagination.js
+++ b/public/src/components/modules/Pagination/Pagination.js
@@ -1,0 +1,53 @@
+import { loadCSS } from '../../../utils/cssLoader.js';
+loadCSS('./src/components/modules/Pagination/Pagination.css');
+
+import { Button } from '../../primitives/Button/Button.js';
+
+export function Pagination({ totalPages = 1, currentPage = 1, onPageChange = () => {} } = {}) {
+  const nav = document.createElement('nav');
+  nav.classList.add('pagination');
+  nav.setAttribute('aria-label', 'Pagination');
+
+  const list = document.createElement('ul');
+  list.classList.add('pagination__list');
+
+  const createPageButton = page => {
+    const li = document.createElement('li');
+    li.classList.add('pagination__item');
+    const btn = Button({ text: String(page), onClick: () => onPageChange(page) });
+    btn.classList.add('pagination__button');
+    btn.setAttribute('aria-label', `Page ${page}`);
+    if (page === currentPage) {
+      btn.setAttribute('aria-current', 'page');
+      btn.disabled = true;
+    }
+    li.append(btn);
+    return li;
+  };
+
+  const prevLi = document.createElement('li');
+  prevLi.classList.add('pagination__item');
+  const prevButton = Button({ text: 'Previous', onClick: () => onPageChange(currentPage - 1) });
+  prevButton.classList.add('pagination__button', 'pagination__prev');
+  prevButton.setAttribute('aria-label', 'Previous page');
+  prevButton.disabled = currentPage <= 1;
+  prevLi.append(prevButton);
+  list.append(prevLi);
+
+  for (let i = 1; i <= totalPages; i++) {
+    list.append(createPageButton(i));
+  }
+
+  const nextLi = document.createElement('li');
+  nextLi.classList.add('pagination__item');
+  const nextButton = Button({ text: 'Next', onClick: () => onPageChange(currentPage + 1) });
+  nextButton.classList.add('pagination__button', 'pagination__next');
+  nextButton.setAttribute('aria-label', 'Next page');
+  nextButton.disabled = currentPage >= totalPages;
+  nextLi.append(nextButton);
+  list.append(nextLi);
+
+  nav.append(list);
+  return nav;
+}
+


### PR DESCRIPTION
## Summary
- add accessible pagination module built from primitives
- include responsive styling for pagination

## Testing
- `npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_689013316f248328945f9cc6b54b462c