### PR TITLE
feat: add accessible tabs module

### DIFF
--- a/public/src/components/modules/Tabs/Tabs.css
+++ b/public/src/components/modules/Tabs/Tabs.css
@@ -1,0 +1,61 @@
+.tabs {
+  width: 100%;
+  max-width: 600px;
+  margin: 1rem auto;
+}
+
+.tabs__heading {
+  margin-bottom: 0.5rem;
+}
+
+.tabs__tablist {
+  display: flex;
+  flex-direction: column;
+  border-bottom: 1px solid #ddd;
+}
+
+.tabs__tab {
+  width: 100%;
+  border: none;
+  border-top: 1px solid #ddd;
+  border-bottom: 2px solid transparent;
+  background: #f9f9f9;
+  cursor: pointer;
+  padding: 0.5rem 1rem;
+  text-align: left;
+}
+
+.tabs__tab:first-child {
+  border-top: none;
+}
+
+.tabs__tab[aria-selected="true"] {
+  background: #fff;
+  border-bottom-color: #333;
+}
+
+.tabs__panel {
+  padding: 1rem;
+  border: 1px solid #ddd;
+}
+
+@media (min-width: 600px) {
+  .tabs__tablist {
+    flex-direction: row;
+  }
+
+  .tabs__tab {
+    width: auto;
+    border-top: none;
+    border-right: 1px solid #ddd;
+  }
+
+  .tabs__tab:last-child {
+    border-right: none;
+  }
+
+  .tabs__panel {
+    padding: 1.5rem;
+  }
+}
+

--- a/public/src/components/modules/Tabs/Tabs.js
+++ b/public/src/components/modules/Tabs/Tabs.js
@@ -1,0 +1,87 @@
+import { loadCSS } from '../../../utils/cssLoader.js';
+loadCSS('./src/components/modules/Tabs/Tabs.css');
+
+import { Heading } from '../../primitives/Heading/Heading.js';
+import { Button } from '../../primitives/Button/Button.js';
+import { Text } from '../../primitives/Text/Text.js';
+
+export function Tabs({
+  heading = 'Tabs',
+  items = []
+} = {}) {
+  const container = document.createElement('section');
+  container.classList.add('tabs');
+
+  const headingEl = Heading({ level: 2, text: heading, className: 'tabs__heading' });
+  container.appendChild(headingEl);
+
+  const tabList = document.createElement('div');
+  tabList.classList.add('tabs__tablist');
+  tabList.setAttribute('role', 'tablist');
+  container.appendChild(tabList);
+
+  const panelsContainer = document.createElement('div');
+  panelsContainer.classList.add('tabs__panels');
+  container.appendChild(panelsContainer);
+
+  function activateTab(activeIndex) {
+    const tabs = tabList.querySelectorAll('.tabs__tab');
+    const panels = panelsContainer.querySelectorAll('.tabs__panel');
+
+    tabs.forEach((tab, index) => {
+      const selected = index === activeIndex;
+      tab.setAttribute('aria-selected', String(selected));
+      tab.tabIndex = selected ? 0 : -1;
+      if (selected) {
+        tab.focus();
+      }
+    });
+
+    panels.forEach((panel, index) => {
+      panel.hidden = index !== activeIndex;
+    });
+  }
+
+  items.forEach((item, index) => {
+    const tabId = `tab-${index}`;
+    const panelId = `panel-${index}`;
+
+    const tab = Button({ text: item.label || `Tab ${index + 1}` });
+    tab.classList.add('tabs__tab');
+    tab.id = tabId;
+    tab.setAttribute('role', 'tab');
+    tab.setAttribute('aria-controls', panelId);
+    tab.setAttribute('aria-selected', String(index === 0));
+    tab.tabIndex = index === 0 ? 0 : -1;
+    tabList.appendChild(tab);
+
+    const panel = document.createElement('div');
+    panel.classList.add('tabs__panel');
+    panel.id = panelId;
+    panel.setAttribute('role', 'tabpanel');
+    panel.setAttribute('aria-labelledby', tabId);
+    if (index !== 0) panel.hidden = true;
+
+    const content = Text({ tag: 'p', text: item.content || '' });
+    panel.appendChild(content);
+    panelsContainer.appendChild(panel);
+
+    tab.addEventListener('click', () => activateTab(index));
+    tab.addEventListener('keydown', (e) => {
+      const { key } = e;
+      let newIndex = null;
+      if (key === 'ArrowRight') {
+        newIndex = (index + 1) % items.length;
+      } else if (key === 'ArrowLeft') {
+        newIndex = (index - 1 + items.length) % items.length;
+      }
+      if (newIndex !== null) {
+        activateTab(newIndex);
+        e.preventDefault();
+      }
+    });
+  });
+
+  return container;
+}
+


### PR DESCRIPTION
## Summary
- add Tabs module built from primitives with keyboard-accessible tab switching
- style Tabs module with responsive CSS

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_689013316f248328945f9cc6b54b462c