### PR TITLE
feat: add ProgressBar module

### DIFF
--- a/public/src/components/modules/ProgressBar/ProgressBar.css
+++ b/public/src/components/modules/ProgressBar/ProgressBar.css
@@ -1,0 +1,36 @@
+.progress-bar {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.progress-bar__label {
+  margin-bottom: 0.25rem;
+  font-weight: 500;
+}
+
+.progress-bar__track {
+  background-color: #e0e0e0;
+  border-radius: 4px;
+  overflow: hidden;
+  height: 1rem;
+}
+
+.progress-bar__fill {
+  background-color: #007bff;
+  height: 100%;
+  width: 0;
+  transition: width 0.3s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .progress-bar__fill {
+    transition: none;
+  }
+}
+
+@media (max-width: 600px) {
+  .progress-bar__label {
+    font-size: 0.875rem;
+  }
+}

--- a/public/src/components/modules/ProgressBar/ProgressBar.js
+++ b/public/src/components/modules/ProgressBar/ProgressBar.js
@@ -1,0 +1,36 @@
+import { loadCSS } from '../../../utils/cssLoader.js';
+loadCSS('./src/components/modules/ProgressBar/ProgressBar.css');
+
+import { Text } from '../../primitives/Text/Text.js';
+
+export function ProgressBar({ value = 0, max = 100, label = '' } = {}) {
+  const container = document.createElement('div');
+  container.classList.add('progress-bar');
+  container.setAttribute('role', 'progressbar');
+  container.setAttribute('aria-valuemin', 0);
+  container.setAttribute('aria-valuemax', max);
+
+  const safeValue = Math.max(0, Math.min(value, max));
+  container.setAttribute('aria-valuenow', safeValue);
+
+  let labelEl;
+  if (label) {
+    const id = `progress-bar-label-${Math.random().toString(36).slice(2, 9)}`;
+    labelEl = Text({ tag: 'span', text: label, className: 'progress-bar__label' });
+    labelEl.id = id;
+    container.setAttribute('aria-labelledby', id);
+    container.appendChild(labelEl);
+  }
+
+  const track = document.createElement('div');
+  track.classList.add('progress-bar__track');
+
+  const fill = document.createElement('div');
+  fill.classList.add('progress-bar__fill');
+  fill.style.width = `${(safeValue / max) * 100}%`;
+
+  track.appendChild(fill);
+  container.appendChild(track);
+
+  return container;
+}


### PR DESCRIPTION
## Summary
- add ProgressBar module built from existing primitives
- style progress bar for responsiveness and reduced motion

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6890145a41448328b83014fdd8efe730