### PR TITLE
feat: add accessible image carousel module

### DIFF
--- a/public/src/components/modules/ImageCarousel/ImageCarousel.css
+++ b/public/src/components/modules/ImageCarousel/ImageCarousel.css
@@ -1,0 +1,50 @@
+.image-carousel {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 100%;
+  margin: 1rem auto;
+}
+
+.image-carousel__figure {
+  margin: 0;
+  width: 100%;
+  text-align: center;
+}
+
+.image-carousel__image {
+  width: 100%;
+  height: auto;
+  display: block;
+  border-radius: 8px;
+}
+
+.image-carousel__caption {
+  margin-top: 0.5rem;
+  color: #555;
+}
+
+.image-carousel__control {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.image-carousel__control--prev {
+  left: 0.5rem;
+}
+
+.image-carousel__control--next {
+  right: 0.5rem;
+}
+
+@media (min-width: 600px) {
+  .image-carousel__control--prev {
+    left: 1rem;
+  }
+
+  .image-carousel__control--next {
+    right: 1rem;
+  }
+}

--- a/public/src/components/modules/ImageCarousel/ImageCarousel.js
+++ b/public/src/components/modules/ImageCarousel/ImageCarousel.js
@@ -1,0 +1,65 @@
+import { loadCSS } from '../../../utils/cssLoader.js';
+loadCSS('./src/components/modules/ImageCarousel/ImageCarousel.css');
+
+import { Button } from '../../primitives/Button/Button.js';
+import { Text } from '../../primitives/Text/Text.js';
+
+export function ImageCarousel({
+  images = [],
+  ariaLabel = 'Image carousel'
+} = {}) {
+  const container = document.createElement('section');
+  container.classList.add('image-carousel');
+  container.setAttribute('role', 'region');
+  container.setAttribute('aria-roledescription', 'carousel');
+  container.setAttribute('aria-label', ariaLabel);
+
+  if (!images.length) {
+    const emptyMessage = Text({ tag: 'p', text: 'No images to display.', className: 'image-carousel__empty' });
+    container.append(emptyMessage);
+    return container;
+  }
+
+  let currentIndex = 0;
+
+  const figure = document.createElement('figure');
+  figure.classList.add('image-carousel__figure');
+
+  const imgEl = document.createElement('img');
+  imgEl.classList.add('image-carousel__image');
+
+  const captionEl = Text({ tag: 'figcaption', text: '', className: 'image-carousel__caption' });
+  captionEl.setAttribute('aria-live', 'polite');
+
+  figure.append(imgEl, captionEl);
+
+  function renderSlide(index) {
+    const item = images[index];
+    imgEl.src = item.src;
+    imgEl.alt = item.alt || '';
+    captionEl.textContent = item.caption || '';
+  }
+
+  const prevButton = Button({ text: 'Prev', onClick: () => {} });
+  prevButton.setAttribute('aria-label', 'Previous slide');
+  prevButton.classList.add('image-carousel__control', 'image-carousel__control--prev');
+
+  const nextButton = Button({ text: 'Next', onClick: () => {} });
+  nextButton.setAttribute('aria-label', 'Next slide');
+  nextButton.classList.add('image-carousel__control', 'image-carousel__control--next');
+
+  prevButton.addEventListener('click', () => {
+    currentIndex = (currentIndex - 1 + images.length) % images.length;
+    renderSlide(currentIndex);
+  });
+
+  nextButton.addEventListener('click', () => {
+    currentIndex = (currentIndex + 1) % images.length;
+    renderSlide(currentIndex);
+  });
+
+  container.append(prevButton, figure, nextButton);
+  renderSlide(currentIndex);
+
+  return container;
+}


### PR DESCRIPTION
## Summary
- build ImageCarousel module using Button and Text primitives
- style carousel with responsive layout and navigation controls

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689017ae3a508328a89e6659f900db9c