### PR TITLE
feat: add language selector module

### DIFF
--- a/public/src/components/modules/LanguageSelector/LanguageSelector.css
+++ b/public/src/components/modules/LanguageSelector/LanguageSelector.css
@@ -1,0 +1,31 @@
+/* public/src/components/modules/LanguageSelector/LanguageSelector.css */
+.language-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.language-selector__title {
+  margin: 0;
+}
+
+.language-selector__control {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+@media (max-width: 480px) {
+  .language-selector__control {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .language-selector__label {
+    margin-bottom: 0.25rem;
+  }
+
+  .language-selector__select {
+    width: 100%;
+  }
+}

--- a/public/src/components/modules/LanguageSelector/LanguageSelector.js
+++ b/public/src/components/modules/LanguageSelector/LanguageSelector.js
@@ -1,0 +1,37 @@
+import { loadCSS } from '../../../utils/cssLoader.js';
+loadCSS('./src/components/modules/LanguageSelector/LanguageSelector.css');
+
+import { Heading } from '../../primitives/Heading/Heading.js';
+import { Label } from '../../primitives/Label/Label.js';
+import { Select } from '../../primitives/Select/Select.js';
+
+export function LanguageSelector({
+  title = 'Select Language',
+  labelText = 'Language',
+  options = [
+    { value: 'en', label: 'English' },
+    { value: 'es', label: 'Spanish' },
+    { value: 'fr', label: 'French' }
+  ],
+  onChange = () => {}
+} = {}) {
+  const container = document.createElement('div');
+  container.classList.add('language-selector');
+
+  const headingEl = Heading({ level: 2, text: title, className: 'language-selector__title' });
+
+  const controlWrapper = document.createElement('div');
+  controlWrapper.classList.add('language-selector__control');
+
+  const labelEl = Label({ htmlFor: 'language-selector-select', text: labelText });
+  labelEl.classList.add('language-selector__label');
+
+  const selectEl = Select({ options, onChange });
+  selectEl.id = 'language-selector-select';
+  selectEl.classList.add('language-selector__select');
+
+  controlWrapper.append(labelEl, selectEl);
+  container.append(headingEl, controlWrapper);
+
+  return container;
+}


### PR DESCRIPTION
## Summary
- add LanguageSelector module built from heading, label and select primitives
- apply responsive styles and accessible markup for language selection

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68901c5fd49483289794d35597858b05