### PR TITLE
Add CookieConsentBanner module

### DIFF
--- a/public/src/components/modules/CookieConsentBanner/CookieConsentBanner.css
+++ b/public/src/components/modules/CookieConsentBanner/CookieConsentBanner.css
@@ -1,0 +1,58 @@
+/* public/src/components/modules/CookieConsentBanner/CookieConsentBanner.css */
+.cookie-consent-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background-color: #f9f9f9;
+  border-top: 1px solid #ddd;
+  padding: 1rem;
+  box-shadow: 0 -2px 4px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+}
+
+.cookie-consent-banner__message {
+  margin: 0 0 1rem;
+}
+
+.cookie-consent-banner__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.cookie-consent-banner__button {
+  width: 100%;
+}
+
+.cookie-consent-banner__link {
+  text-align: center;
+  font-size: 0.875rem;
+}
+
+@media (min-width: 600px) {
+  .cookie-consent-banner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .cookie-consent-banner__message {
+    margin: 0;
+    max-width: 60%;
+  }
+
+  .cookie-consent-banner__actions {
+    flex-direction: row;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .cookie-consent-banner__button {
+    width: auto;
+  }
+
+  .cookie-consent-banner__link {
+    margin-left: 1rem;
+  }
+}

--- a/public/src/components/modules/CookieConsentBanner/CookieConsentBanner.js
+++ b/public/src/components/modules/CookieConsentBanner/CookieConsentBanner.js
@@ -1,0 +1,45 @@
+import { loadCSS } from '../../../utils/cssLoader.js';
+loadCSS('./src/components/modules/CookieConsentBanner/CookieConsentBanner.css');
+
+import { Text } from '../../primitives/Text/Text.js';
+import { Button } from '../../primitives/Button/Button.js';
+import { Link } from '../../primitives/Link/Link.js';
+
+export function CookieConsentBanner({
+  message = 'We use cookies to ensure you get the best experience.',
+  moreInfoUrl = '#',
+  onAccept = () => {},
+  onDecline = () => {}
+} = {}) {
+  const banner = document.createElement('div');
+  banner.classList.add('cookie-consent-banner');
+  banner.setAttribute('role', 'dialog');
+  banner.setAttribute('aria-live', 'polite');
+  banner.setAttribute('aria-label', 'Cookie consent');
+
+  const messageEl = Text({ tag: 'p', text: message, className: 'cookie-consent-banner__message' });
+
+  const actions = document.createElement('div');
+  actions.classList.add('cookie-consent-banner__actions');
+
+  const acceptBtn = Button({ text: 'Accept', onClick: () => {
+    onAccept();
+    banner.remove();
+  }});
+  acceptBtn.classList.add('cookie-consent-banner__button', 'cookie-consent-banner__button--accept');
+
+  const declineBtn = Button({ text: 'Decline', onClick: () => {
+    onDecline();
+    banner.remove();
+  }});
+  declineBtn.classList.add('cookie-consent-banner__button', 'cookie-consent-banner__button--decline');
+
+  const infoLink = Link({ href: moreInfoUrl, text: 'Learn more', target: '_blank' });
+  infoLink.classList.add('cookie-consent-banner__link');
+  infoLink.setAttribute('rel', 'noopener noreferrer');
+
+  actions.append(acceptBtn, declineBtn, infoLink);
+  banner.append(messageEl, actions);
+
+  return banner;
+}


### PR DESCRIPTION
## Summary
- add accessible CookieConsentBanner module composed from primitives
- style banner responsively for small and large screens

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68901ff088648328be2e7154bb9e8f96