### PR TITLE
feat: add toast notification module

### DIFF
--- a/public/src/components/modules/ToastNotification/ToastNotification.css
+++ b/public/src/components/modules/ToastNotification/ToastNotification.css
@@ -1,0 +1,56 @@
+/* public/src/components/modules/ToastNotification/ToastNotification.css */
+.toast-notification {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background-color: #333;
+  color: #fff;
+  padding: 1rem 1.5rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  max-width: calc(100% - 2rem);
+  z-index: 1000;
+}
+
+.toast-notification__message {
+  flex: 1;
+  margin: 0;
+}
+
+.toast-notification__close {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.toast-notification--success {
+  background-color: #28a745;
+}
+
+.toast-notification--error {
+  background-color: #dc3545;
+}
+
+.toast-notification--info {
+  background-color: #007bff;
+}
+
+.toast-notification--warning {
+  background-color: #ffc107;
+  color: #000;
+}
+
+@media (max-width: 480px) {
+  .toast-notification {
+    left: 1rem;
+    right: 1rem;
+    bottom: 1rem;
+    max-width: none;
+  }
+}

--- a/public/src/components/modules/ToastNotification/ToastNotification.js
+++ b/public/src/components/modules/ToastNotification/ToastNotification.js
@@ -1,0 +1,36 @@
+import { loadCSS } from '../../../utils/cssLoader.js';
+loadCSS('./src/components/modules/ToastNotification/ToastNotification.css');
+
+import { Text } from '../../primitives/Text/Text.js';
+import { Button } from '../../primitives/Button/Button.js';
+
+export function ToastNotification({
+  message = 'Notification message',
+  type = 'info',
+  duration = 3000,
+  onClose = () => {},
+} = {}) {
+  const toast = document.createElement('div');
+  toast.classList.add('toast-notification', `toast-notification--${type}`);
+  toast.setAttribute('role', 'alert');
+  toast.setAttribute('aria-live', 'polite');
+
+  const messageEl = Text({ tag: 'span', text: message, className: 'toast-notification__message' });
+
+  const closeBtn = Button({ text: '\u00D7', onClick: handleClose });
+  closeBtn.classList.add('toast-notification__close');
+  closeBtn.setAttribute('aria-label', 'Dismiss notification');
+
+  toast.append(messageEl, closeBtn);
+
+  if (duration) {
+    setTimeout(handleClose, duration);
+  }
+
+  function handleClose() {
+    toast.remove();
+    onClose();
+  }
+
+  return toast;
+}


### PR DESCRIPTION
## Summary
- add accessible ToastNotification module built from primitives
- style toast notification with responsive CSS and variant states

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6890bc8f5d808328818f1073f02c85c2