### PR TITLE
feat: add star rating module

### DIFF
--- a/public/src/components/modules/StarRating/StarRating.css
+++ b/public/src/components/modules/StarRating/StarRating.css
@@ -1,0 +1,39 @@
+.star-rating {
+  border: none;
+  padding: 0.5rem;
+}
+
+.star-rating__legend {
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+}
+
+.star-rating__stars {
+  display: inline-flex;
+  flex-direction: row-reverse;
+  justify-content: flex-end;
+}
+
+.star-rating__input {
+  position: absolute;
+  opacity: 0;
+}
+
+.star-rating__label {
+  font-size: 1.5rem;
+  color: #ccc;
+  cursor: pointer;
+  padding: 0 0.1rem;
+}
+
+.star-rating__label:hover,
+.star-rating__label:hover ~ .star-rating__label,
+.star-rating__input:checked ~ .star-rating__label {
+  color: #f5b301;
+}
+
+@media (min-width: 600px) {
+  .star-rating__label {
+    font-size: 2rem;
+  }
+}

--- a/public/src/components/modules/StarRating/StarRating.js
+++ b/public/src/components/modules/StarRating/StarRating.js
@@ -1,0 +1,46 @@
+import { loadCSS } from '../../../utils/cssLoader.js';
+loadCSS('./src/components/modules/StarRating/StarRating.css');
+
+import { Input } from '../../primitives/Input/Input.js';
+import { Label } from '../../primitives/Label/Label.js';
+import { Text } from '../../primitives/Text/Text.js';
+
+export function StarRating({
+  name = 'rating',
+  max = 5,
+  value = 0,
+  legend = 'Rate this',
+  onChange,
+} = {}) {
+  const fieldset = document.createElement('fieldset');
+  fieldset.classList.add('star-rating');
+
+  const legendEl = Text({ tag: 'legend', text: legend, className: 'star-rating__legend' });
+  fieldset.appendChild(legendEl);
+
+  const stars = document.createElement('div');
+  stars.classList.add('star-rating__stars');
+  fieldset.appendChild(stars);
+
+  for (let i = max; i >= 1; i--) {
+    const id = `${name}-${i}`;
+    const input = Input({ type: 'radio', value: String(i) });
+    input.name = name;
+    input.id = id;
+    input.classList.add('star-rating__input');
+    if (i === value) {
+      input.checked = true;
+    }
+    if (typeof onChange === 'function') {
+      input.addEventListener('change', e => onChange(Number(e.target.value)));
+    }
+
+    const label = Label({ htmlFor: id, text: '★' });
+    label.classList.add('star-rating__label');
+    label.setAttribute('aria-label', `${i} star${i > 1 ? 's' : ''}`);
+
+    stars.append(input, label);
+  }
+
+  return fieldset;
+}


### PR DESCRIPTION
## Summary
- add new StarRating module composed from primitive components
- style rating stars with responsive sizes and highlight interactions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6890c04eab808328b3f1be7e8b57ec94