### PR TITLE
feat: add FileUpload module

### DIFF
--- a/public/src/components/modules/FileUpload/FileUpload.css
+++ b/public/src/components/modules/FileUpload/FileUpload.css
@@ -1,0 +1,33 @@
+.file-upload {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: flex-start;
+}
+
+.file-upload__controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.file-upload__input {
+  flex: 1;
+}
+
+.file-upload__filename {
+  font-size: 0.875rem;
+  color: #555;
+}
+
+@media (max-width: 600px) {
+  .file-upload__controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .file-upload__button {
+    width: 100%;
+  }
+}

--- a/public/src/components/modules/FileUpload/FileUpload.js
+++ b/public/src/components/modules/FileUpload/FileUpload.js
@@ -1,0 +1,51 @@
+import { loadCSS } from '../../../utils/cssLoader.js';
+loadCSS('./src/components/modules/FileUpload/FileUpload.css');
+
+import { Label } from '../../primitives/Label/Label.js';
+import { Input } from '../../primitives/Input/input.js';
+import { Button } from '../../primitives/Button/Button.js';
+import { Text } from '../../primitives/Text/Text.js';
+
+export function FileUpload({
+  labelText = 'Upload file',
+  buttonText = 'Upload',
+  accept = '',
+  onUpload = () => {}
+} = {}) {
+  const form = document.createElement('form');
+  form.classList.add('file-upload');
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    const file = inputEl.files[0];
+    if (file) {
+      onUpload(file);
+    }
+  });
+
+  const labelEl = Label({ htmlFor: 'file-upload-input', text: labelText });
+  labelEl.classList.add('file-upload__label');
+
+  const controlsEl = document.createElement('div');
+  controlsEl.classList.add('file-upload__controls');
+
+  const inputEl = Input({ type: 'file' });
+  inputEl.id = 'file-upload-input';
+  inputEl.accept = accept;
+  inputEl.classList.add('file-upload__input');
+
+  const buttonEl = Button({ text: buttonText, type: 'submit', onClick: () => {} });
+  buttonEl.classList.add('file-upload__button');
+
+  const fileNameEl = Text({ tag: 'span', text: 'No file selected', className: 'file-upload__filename' });
+  fileNameEl.setAttribute('aria-live', 'polite');
+
+  inputEl.addEventListener('change', () => {
+    const name = inputEl.files[0]?.name || 'No file selected';
+    fileNameEl.textContent = name;
+  });
+
+  controlsEl.append(inputEl, buttonEl);
+  form.append(labelEl, controlsEl, fileNameEl);
+
+  return form;
+}


### PR DESCRIPTION
## Summary
- add FileUpload module using primitives for accessible file uploads
- apply responsive styles for FileUpload

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6890c39c737483288cae6ec783989623